### PR TITLE
feat: support manual bump dispatch

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -3,11 +3,20 @@ name: Bump Version
 on:
   pull_request:
     types: [closed]
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
 
 jobs:
 
   bump-version:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -19,5 +28,6 @@ jobs:
           label-major: 'update::major'
           label-minor: 'update::minor'
           label-patch: 'update::patch'
+          # manual-bump-type: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.bump_type || '' }}
           labels-to-add: 'automated,versioning'
           create-release: 'true'

--- a/README.md
+++ b/README.md
@@ -223,7 +223,8 @@ Follow these steps to configure the permissions:
 
 2. Determines the bump type
    - For manual workflow dispatches, uses `manual-bump-type`.
-   - Otherwise, extracts PR labels and determines whether a major, minor, or patch bump is required, in accordance with semantic versioning.
+   - Otherwise, extracts PR labels and determines whether a major, minor, or patch bump is required,
+     in accordance with semantic versioning.
    - If no matching labels are found, the process stops.
 
 3. Runs `bump-my-version` to bump the version

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ incrementing the version number based on the labels applied to the PR.
 ## Features
 
 - Automatically determines the version bump type based on PR labels.
+- Supports manual workflow dispatch with an explicitly selected bump type.
 - Uses [bump-my-version](https://github.com/callowayproject/bump-my-version)
   to increment the version according to semantic versioning.
 - Creates a new branch and a PR for the version bump.
@@ -24,7 +25,6 @@ You can save them in a file such as `.github/workflows/bump-version.yaml`.
 Make sure your workflow includes the following:
 
 - The `on: pull_request: types: [closed]` trigger to run the workflow whenever a PR is closed.
-- The condition `if: github.event.pull_request.merged == true` to ensure the workflow only proceeds if the PR was merged.
 - The `permissions:` section to allow the workflow to update repository contents and PRs.
 
 #### Basic Example
@@ -38,7 +38,6 @@ on:
 
 jobs:
   bump-version:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -50,6 +49,46 @@ jobs:
           label-major: 'major update'
           label-minor: 'minor update'
           label-patch: 'patch update'
+          labels-to-add: 'automated,version-bump'
+          create-release: 'true'
+```
+
+#### Example with Manual Dispatch
+
+You can also use this action with manual workflow dispatch.
+The following example adds a manual trigger that lets you choose the bump type when starting the workflow.
+
+```yaml
+name: Bump Version
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Bump Version
+        uses: conjikidow/bump-version-action@v3.0.0
+        with:
+          label-major: 'major update'
+          label-minor: 'minor update'
+          label-patch: 'patch update'
+          manual-bump-type: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.bump_type || '' }}
           labels-to-add: 'automated,version-bump'
           create-release: 'true'
 ```
@@ -69,7 +108,6 @@ on:
 
 jobs:
   bump-version:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -105,6 +143,7 @@ jobs:
 | `label-major`                | The label used to trigger a major version bump.   | No       | `'major'`             |
 | `label-minor`                | The label used to trigger a minor version bump.   | No       | `'minor'`             |
 | `label-patch`                | The label used to trigger a patch version bump.   | No       | `'patch'`             |
+| `manual-bump-type`           | The bump type to use for manual workflow runs.    | No       | `''`                  |
 | `branch-prefix`              | The prefix for the version bump branch name.      | No       | `'workflow'`          |
 | `labels-to-add`              | Comma-separated labels to add to the bump PR.     | No       | `''`                  |
 | `create-release`             | Create a GitHub Release for the new tag.          | No       | `'false'`             |
@@ -112,6 +151,9 @@ jobs:
 <!-- markdownlint-disable MD028 -->
 > [!TIP]
 > Set any of `label-major`, `label-minor`, or `label-patch` to an empty string (`''`) if you want to disable that bump type.
+
+> [!NOTE]
+> Set `manual-bump-type` to one of `major`, `minor`, or `patch` when the workflow is triggered manually.
 
 > [!WARNING]
 > Any labels specified in `labels-to-add` must already exist in your repository.
@@ -175,11 +217,13 @@ Follow these steps to configure the permissions:
 
 ## How It Works
 
-1. Checks if the PR is merged
-   - If not merged, the action skips execution.
+1. Checks the execution conditions
+   - Runs for merged pull requests and manual workflow dispatches.
+   - For other cases, the action skips execution.
 
 2. Determines the bump type
-   - Extracts PR labels and determines whether a major, minor, or patch bump is required, in accordance with semantic versioning.
+   - For manual workflow dispatches, uses `manual-bump-type`.
+   - Otherwise, extracts PR labels and determines whether a major, minor, or patch bump is required, in accordance with semantic versioning.
    - If no matching labels are found, the process stops.
 
 3. Runs `bump-my-version` to bump the version

--- a/action.yaml
+++ b/action.yaml
@@ -70,9 +70,7 @@ runs:
           echo "Skipping job because the event is unsupported: ${{ github.event_name }}"
         fi
 
-        {
-          echo "SKIP_JOB=true" >> "$GITHUB_ENV"
-        }
+        echo "SKIP_JOB=true" >> "$GITHUB_ENV"
 
     - name: Checkout repository
       if: env.SKIP_JOB != 'true'

--- a/action.yaml
+++ b/action.yaml
@@ -23,6 +23,10 @@ inputs:
     description: 'The label used to trigger a patch version bump.'
     required: false
     default: 'patch'
+  manual-bump-type:
+    description: 'The bump type to use for manual workflow dispatch runs.'
+    required: false
+    default: ''
   branch-prefix:
     description: 'The prefix for the version bump branch name.'
     required: false
@@ -46,14 +50,29 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: Check if PR is merged
+    - name: Check execution conditions
       shell: bash
       run: |
-        if [[ -z "${{ github.event.pull_request.merged }}" || \
-              "${{ github.event.pull_request.merged }}" != "true" ]]; then
-          echo "Skipping job because the pull request is not merged."
-          echo "SKIP_JOB=true" >> "$GITHUB_ENV"
+        if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          echo "Manual workflow dispatch detected."
+          exit 0
         fi
+
+        if [[ "${{ github.event_name }}" == "pull_request" && \
+              "${{ github.event.pull_request.merged }}" == "true" ]]; then
+          echo "Merged pull request detected."
+          exit 0
+        fi
+
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          echo "Skipping job because the pull request is not merged."
+        else
+          echo "Skipping job because the event is unsupported: ${{ github.event_name }}"
+        fi
+
+        {
+          echo "SKIP_JOB=true" >> "$GITHUB_ENV"
+        }
 
     - name: Checkout repository
       if: env.SKIP_JOB != 'true'
@@ -74,12 +93,14 @@ runs:
       id: bump-type
       shell: bash
       env:
+        EVENT_NAME: ${{ github.event_name }}
         GH_TOKEN: ${{ inputs.github-token }}
         REPO: ${{ github.repository }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
         LABEL_MAJOR: ${{ inputs.label-major }}
         LABEL_MINOR: ${{ inputs.label-minor }}
         LABEL_PATCH: ${{ inputs.label-patch }}
+        MANUAL_BUMP_TYPE: ${{ inputs.manual-bump-type }}
       run: ${{ github.action_path }}/src/determine-bump-type.sh
 
     - name: Install uv

--- a/src/determine-bump-type.sh
+++ b/src/determine-bump-type.sh
@@ -6,6 +6,38 @@ if ! command -v gh &>/dev/null; then
   exit 1
 fi
 
+validate_manual_bump_type() {
+  case "$1" in
+  major | minor | patch | "")
+    return 0
+    ;;
+  *)
+    return 1
+    ;;
+  esac
+}
+
+if ! validate_manual_bump_type "${MANUAL_BUMP_TYPE:-}"; then
+  echo "Error: manual-bump-type must be one of 'major', 'minor', 'patch', or empty." >&2
+  exit 1
+fi
+
+if [[ ${EVENT_NAME} == "workflow_dispatch" ]]; then
+  if [[ -z ${MANUAL_BUMP_TYPE} ]]; then
+    echo "Error: manual-bump-type is required for workflow_dispatch events." >&2
+    exit 1
+  fi
+
+  echo "Using manual bump type: ${MANUAL_BUMP_TYPE}"
+  echo "type=${MANUAL_BUMP_TYPE}" >>"$GITHUB_OUTPUT"
+  exit 0
+fi
+
+if [[ ${EVENT_NAME} != "pull_request" ]]; then
+  echo "Unsupported event for bump type determination: ${EVENT_NAME}" >&2
+  exit 1
+fi
+
 # Fetch PR labels
 echo "Fetching PR labels..."
 labels=$(gh api --jq '.labels.[].name' "/repos/${REPO}/pulls/${PR_NUMBER}" | tr '\n' ',' | sed 's/,$//')


### PR DESCRIPTION
- add `manual-bump-type` so the action can resolve bump type from `workflow_dispatch` as well as merged pull requests
- keep the existing post-merge tag and release flow unchanged while broadening only the trigger-side logic
- update README to document manual dispatch usage and the simplified caller setup