### PR TITLE
feat!: add update-major-minor-tags input to opt in to rolling tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ jobs:
 | `manual-bump-type`           | The bump type to use for manual workflow runs.    | No       | `''`                  |
 | `branch-prefix`              | The prefix for the version bump branch name.      | No       | `'workflow'`          |
 | `labels-to-add`              | Comma-separated labels to add to the bump PR.     | No       | `''`                  |
+| `update-major-minor-tags`    | Update the major (`vX`) and minor (`vX.Y`) tags.  | No       | `'false'`             |
 | `create-release`             | Create a GitHub Release for the new tag.          | No       | `'false'`             |
 
 <!-- markdownlint-disable MD028 -->
@@ -245,8 +246,20 @@ Follow these steps to configure the permissions:
 
 ### Tag Management
 
-In addition to the full version tag (`vX.Y.Z`), this action updates existing
-major (`vX`) and minor (`vX.Y`) tags based on the following rules:
+By default, this action only creates the full version tag (`vX.Y.Z`), which is never overwritten on subsequent releases.
+This default is compatible with GitHub's [Immutable Releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases)
+setting and aligns with the recommendation to pin actions to specific versions
+(ideally to a commit SHA) for supply chain security.
+
+> [!NOTE]
+> True immutability of tags and releases requires enabling **Enable release immutability**
+> in your repository's **Settings → General → Releases**.
+> This action's default behavior is designed to be compatible with that setting.
+
+#### Enabling Major and Minor Tag Updates
+
+If `update-major-minor-tags` is set to `'true'`, the action also creates or updates
+the major (`vX`) and minor (`vX.Y`) tags based on the following rules:
 
 - If `vX.Y` exists → update to `vX.Y.Z`.
 - If `vX.Y` does not exist but a previous minor tag (`vX.Y` before the update) exists → create `vX.Y` and set it to `vX.Y.Z`.
@@ -254,11 +267,16 @@ major (`vX`) and minor (`vX.Y`) tags based on the following rules:
 - If `vX` does not exist but a previous major tag (`vX` before the update) exists → create `vX` and set it to `vX.Y.Z`.
 - If neither `vX` nor `vX.Y` exist, they are not created.
 
-#### Examples
+Examples:
 
 - `v1.2.3 → v1.2.4`: Update `v1.2` and `v1` if they exist.
 - `v1.2.3 → v1.3.0`: Create `v1.3` if `v1.2` exists, update `v1` if it exists.
 - `v1.2.3 → v2.0.0`: Create `v2.0` if `v1.2` exists, create `v2` if `v1` exists.
+
+> [!WARNING]
+> Updating major and minor tags requires force-pushing them,
+> which is incompatible with the **Enable release immutability** repository setting.
+> Enabling this option is discouraged for projects that prioritize supply chain security.
 
 ## Contributing & Feedback
 

--- a/action.yaml
+++ b/action.yaml
@@ -35,6 +35,10 @@ inputs:
     description: 'Comma-separated string of labels to add to the PR for version bumping.'
     required: false
     default: ''
+  update-major-minor-tags:
+    description: 'Whether to create or update the major (`vX`) and minor (`vX.Y`) tags to point to the new release.'
+    required: false
+    default: 'false'
   create-release:
     description: 'Whether to create a GitHub Release for the new tag.'
     required: false
@@ -125,6 +129,7 @@ runs:
         HEAD_REF: ${{ github.event.pull_request.head.ref }}
         MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         BRANCH_PREFIX: ${{ inputs.branch-prefix }}
+        UPDATE_MAJOR_MINOR_TAGS: ${{ inputs.update-major-minor-tags }}
       run: ${{ github.action_path }}/src/create-tag.sh
 
     - name: Create GitHub Release

--- a/src/create-tag.sh
+++ b/src/create-tag.sh
@@ -33,33 +33,35 @@ echo "Creating new tag: v${new_version}"
 git tag "v${new_version}" "$MERGE_COMMIT_SHA"
 git push origin "v${new_version}"
 
-# Fetch all tags from the remote
-all_tags=$(git ls-remote --tags origin)
+if [[ ${UPDATE_MAJOR_MINOR_TAGS:-false} == "true" ]]; then
+  # Fetch all tags from the remote
+  all_tags=$(git ls-remote --tags origin)
 
-# Check for existing tags in the fetched list
-existing_previous_major_tag=$(echo "$all_tags" | awk '{print $2}' | grep -E "^refs/tags/v${previous_major_version}$" || true)
-existing_previous_minor_tag=$(echo "$all_tags" | awk '{print $2}' | grep -E "^refs/tags/v${previous_minor_version}$" || true)
-existing_major_tag=$(echo "$all_tags" | awk '{print $2}' | grep -E "^refs/tags/v${new_major_version}$" || true)
-existing_minor_tag=$(echo "$all_tags" | awk '{print $2}' | grep -E "^refs/tags/v${new_minor_version}$" || true)
+  # Check for existing tags in the fetched list
+  existing_previous_major_tag=$(echo "$all_tags" | awk '{print $2}' | grep -E "^refs/tags/v${previous_major_version}$" || true)
+  existing_previous_minor_tag=$(echo "$all_tags" | awk '{print $2}' | grep -E "^refs/tags/v${previous_minor_version}$" || true)
+  existing_major_tag=$(echo "$all_tags" | awk '{print $2}' | grep -E "^refs/tags/v${new_major_version}$" || true)
+  existing_minor_tag=$(echo "$all_tags" | awk '{print $2}' | grep -E "^refs/tags/v${new_minor_version}$" || true)
 
-if [[ -n $existing_major_tag ]]; then
-  echo "Updating major tag: v${new_major_version}"
-  git tag -f "v${new_major_version}" "$MERGE_COMMIT_SHA"
-  git push -f origin "v${new_major_version}"
-elif [[ -n $existing_previous_major_tag ]]; then
-  echo "Creating new major tag: v${new_major_version} (previous major v${previous_major_version} exists)"
-  git tag "v${new_major_version}" "$MERGE_COMMIT_SHA"
-  git push origin "v${new_major_version}"
-fi
+  if [[ -n $existing_major_tag ]]; then
+    echo "Updating major tag: v${new_major_version}"
+    git tag -f "v${new_major_version}" "$MERGE_COMMIT_SHA"
+    git push -f origin "v${new_major_version}"
+  elif [[ -n $existing_previous_major_tag ]]; then
+    echo "Creating new major tag: v${new_major_version} (previous major v${previous_major_version} exists)"
+    git tag "v${new_major_version}" "$MERGE_COMMIT_SHA"
+    git push origin "v${new_major_version}"
+  fi
 
-if [[ -n $existing_minor_tag ]]; then
-  echo "Updating minor tag: v${new_minor_version}"
-  git tag -f "v${new_minor_version}" "$MERGE_COMMIT_SHA"
-  git push -f origin "v${new_minor_version}"
-elif [[ -n $existing_previous_minor_tag ]]; then
-  echo "Creating new minor tag: v${new_minor_version} (previous minor v${previous_minor_version} exists)"
-  git tag "v${new_minor_version}" "$MERGE_COMMIT_SHA"
-  git push origin "v${new_minor_version}"
+  if [[ -n $existing_minor_tag ]]; then
+    echo "Updating minor tag: v${new_minor_version}"
+    git tag -f "v${new_minor_version}" "$MERGE_COMMIT_SHA"
+    git push -f origin "v${new_minor_version}"
+  elif [[ -n $existing_previous_minor_tag ]]; then
+    echo "Creating new minor tag: v${new_minor_version} (previous minor v${previous_minor_version} exists)"
+    git tag "v${new_minor_version}" "$MERGE_COMMIT_SHA"
+    git push origin "v${new_minor_version}"
+  fi
 fi
 
 echo "version-bumped=true" >>"$GITHUB_OUTPUT"


### PR DESCRIPTION
Make rolling `vX` / `vX.Y` tag updates opt-in via a new `update-major-minor-tags` input (default `'false'`).
By default the action now only creates the immutable `vX.Y.Z` tag, which is compatible with GitHub's [Immutable Releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases) setting and aligns with current supply chain security best practice.

Users who relied on the previous behavior must set `update-major-minor-tags: 'true'` to keep updating major and minor tags.

Closes #109
