### PR TITLE
ci(sync-labels): align manual trigger order

### DIFF
--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -1,6 +1,7 @@
 name: Sync Labels
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -12,7 +13,6 @@ on:
     paths:
       - '.github/workflows/sync-labels.yaml'
       - '.github/labels/label-definition.yaml'
-  workflow_dispatch:
 
 jobs:
 


### PR DESCRIPTION
- Move `workflow_dispatch` to the top of the sync-labels trigger list.
