### PR TITLE
ci: split changed JSON5 file list on newlines

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,8 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
+          safe_output: false
+          separator: "\n"
           files_yaml: |
             github_actions:
               - .github/workflows/**
@@ -214,7 +216,7 @@ jobs:
           CHANGED_JSON5_FILES: ${{ needs.determine-changes.outputs.json5_files }}
         run: |
           readarray -t json5_files < <(
-            printf '%s\n' "${CHANGED_JSON5_FILES}" | tr ' ' '\n' | sed '/^$/d'
+            printf '%s\n' "${CHANGED_JSON5_FILES}" | sed '/^$/d'
           )
           if [ ${#json5_files[@]} -eq 0 ]; then
             readarray -d '' -t json5_files < <(


### PR DESCRIPTION
The changed-files output was space-separated and split with `tr`, so a JSON5 path containing spaces was broken into nonexistent paths.
Use a newline separator and drop the `tr`-based splitting.

`safe_output` defaults to `true` and escapes non-printable characters, so the newline separator itself was emitted as a backslash followed by a newline, corrupting every entry but the last.
The list is only consumed via an environment variable, never interpolated into a script, so the escaping is unnecessary.
