### PR TITLE
ci(bump-version): add merged guard and use inputs context

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -29,6 +29,6 @@ jobs:
           label-major: 'update::major'
           label-minor: 'update::minor'
           label-patch: 'update::patch'
-          manual-bump-type: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.bump_type || '' }}
+          manual-bump-type: ${{ inputs.bump_type }}
           labels-to-add: 'automated,versioning'
           create-release: 'true'

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -17,6 +17,7 @@ on:
 jobs:
 
   bump-version:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
The job previously started a runner for every closed pull request and relied on the action's internal guard to no-op.
Evaluate the same condition at the job level so unmerged closures never provision a runner, following the pattern recommended by the GitHub Actions docs for the closed activity type.

The `inputs` context is the current canonical way to read `workflow_dispatch` inputs and preserves input types.
It also resolves to an empty string on `pull_request` events, so the event-name guard in the expression is no longer needed.
No behavioral change.
