### PR TITLE
ci: report lint findings outside the pull request diff

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,6 +96,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
+          filter_mode: nofilter
           fail_level: error
 
       - name: Run zizmor
@@ -192,6 +193,7 @@ jobs:
               -efm="%f:%l %m" \
               -name=markdownlint \
               -reporter=github-pr-review \
+              -filter-mode=nofilter \
               -fail-level=error || reviewdog_rc=$?
           if [ $markdownlint_rc -ne 0 ] && ! grep -Eq '^[^:]+:[0-9]+(:[0-9]+)? ' /tmp/markdownlint-report.txt; then
             echo "::error title=markdownlint::markdownlint failed before producing parseable diagnostics"
@@ -292,6 +294,7 @@ jobs:
               -efm="%f:%l:%c: %t: %m" \
               -name=tombi-lint \
               -reporter=github-pr-review \
+              -filter-mode=nofilter \
               -fail-level=error || reviewdog_rc=$?
           if [ $lint_rc -ne 0 ] && [ ! -s /tmp/tombi-lint-report.efm.txt ]; then
             echo "::error title=tombi::tombi lint failed before producing parseable diagnostics"
@@ -348,6 +351,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
+          filter_mode: nofilter
           fail_level: error
           yamllint_flags: .
 
@@ -414,6 +418,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
+          filter_mode: nofilter
           fail_level: error
 
   check-prek:
@@ -458,6 +463,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
+          filter_mode: nofilter
           fail_level: error
           typos_flags: .
 


### PR DESCRIPTION
reviewdog discards findings that fall outside the lines a pull request changes, so `fail_level` never fires for them and the lint job stays green while the violation remains.
Rules that begin applying to existing code therefore pass every lint job, leaving `check-prek` as the only thing that catches them.

`nofilter` reports and counts every finding.
Where the GitHub review API cannot place an inline comment, reviewdog falls back:

- a changed line — inline review comment
- an untouched line of a changed file — file level comment linking to the line
- a file the pull request does not touch — GitHub Actions annotation

Applied to the reviewdog based lint steps for actionlint, markdownlint, tombi lint, yamllint, shellcheck and typos.

The `action-suggester` steps keep their default, since GitHub suggestions only support the `added` and `diff_context` modes and the format checks already gate on `git diff --exit-code` across every file.
