### PR TITLE
chore: migrate markdown linting to rumdl

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -49,12 +49,14 @@
       managerFilePatterns: [
         '/^\\.github/workflows/ci\\.ya?ml$/',
       ],
+      matchStringsStrategy: 'recursive',
       matchStrings: [
-        'markdownlint-cli2@(?<currentValue>\\S+)',
+        "uses: rvben/rumdl@[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+version: '[^'\\s]+'",
+        "\\n\\s+version: '(?<currentValue>[^'\\s]+)'",
       ],
-      datasourceTemplate: 'npm',
-      depNameTemplate: 'DavidAnson/markdownlint-cli2',
-      packageNameTemplate: 'markdownlint-cli2',
+      datasourceTemplate: 'pypi',
+      depNameTemplate: 'rvben/rumdl',
+      packageNameTemplate: 'rumdl',
     },
     {
       customType: 'regex',
@@ -138,9 +140,10 @@
     },
     {
       matchDepNames: [
-        'DavidAnson/markdownlint-cli2',
+        'rvben/rumdl',
+        'rvben/rumdl-pre-commit',
       ],
-      groupName: 'markdownlint-cli2',
+      groupName: 'rumdl',
     },
     {
       matchDepNames: [

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
               - .github/renovate.json5
             md:
               - '**/*.md'
-              - .markdownlint-cli2.yaml
+              - .rumdl.toml
             json5:
               - '**/*.json5'
             toml:
@@ -162,7 +162,6 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
-      pull-requests: write
 
     steps:
       - name: Checkout the main repository
@@ -171,35 +170,10 @@ jobs:
           persist-credentials: false
 
       - name: Lint Markdown
-        if: github.event_name != 'pull_request'
-        run: npx --yes markdownlint-cli2@0.23.2 .
-
-      - name: Set up reviewdog
-        if: github.event_name == 'pull_request'
-        uses: reviewdog/action-setup@d8a7baabd7f3e8544ee4dbde3ee41d0011c3a93f # v1.5.0
+        uses: rvben/rumdl@4997ff07b63c7a54d6a495ebcd3ce7f23ee1173f # v0.2.55
         with:
-          reviewdog_version: 'v0.21.0'
-
-      - name: Lint Markdown (reviewdog)
-        if: github.event_name == 'pull_request'
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          markdownlint_rc=0
-          npx --yes markdownlint-cli2@0.23.2 . > /tmp/markdownlint-report.txt 2>&1 || markdownlint_rc=$?
-          reviewdog_rc=0
-          reviewdog < /tmp/markdownlint-report.txt \
-              -efm="%f:%l:%c %m" \
-              -efm="%f:%l %m" \
-              -name=markdownlint \
-              -reporter=github-pr-review \
-              -filter-mode=nofilter \
-              -fail-level=error || reviewdog_rc=$?
-          if [ $markdownlint_rc -ne 0 ] && ! grep -Eq '^[^:]+:[0-9]+(:[0-9]+)? ' /tmp/markdownlint-report.txt; then
-            echo "::error title=markdownlint::markdownlint failed before producing parseable diagnostics"
-            exit $markdownlint_rc
-          fi
-          exit $reviewdog_rc
+          version: '0.2.55'
+          report-type: annotations
 
   lint-json5:
     name: Lint JSON5

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,7 +1,0 @@
----
-gitignore: true
-
-config:
-  MD013:
-    line_length: 120
-    tables: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,10 +8,10 @@ repos:
       - id: typos
         args: ["--force-exclude"]
 
-  - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: b82a6c8896e491b9cb377a99ff3412131920681b  # frozen: v0.23.2
+  - repo: https://github.com/rvben/rumdl-pre-commit
+    rev: 4f7fb84c204d04a8b458ad18ca6cd63417d524a9  # frozen: v0.2.55
     hooks:
-      - id: markdownlint-cli2
+      - id: rumdl
 
   - repo: https://github.com/tombi-toml/tombi-pre-commit
     rev: 7fd33d1d0a5b52dcc5aaae94c68cc90a9926271e  # frozen: v1.2.10

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,0 +1,2 @@
+[MD013]
+line-length = 120


### PR DESCRIPTION
Migrate Markdown linting from markdownlint-cli2 to [rumdl](https://github.com/rvben/rumdl), pinned to v0.2.55.

- Convert `.markdownlint-cli2.yaml` to `.rumdl.toml`. rumdl exempts tables from MD013 and respects `.gitignore` by default, so only `line-length` remains.
- Swap the pre-commit hook to `rvben/rumdl-pre-commit`.
- Replace the CI job body with the rumdl action using `report-type: annotations`, dropping the reviewdog setup, its errorformat parsing and the `pull-requests: write` permission.
- Update the Renovate custom manager and group the action pin, the `version` input and the pre-commit hook under `rumdl`.

Note that Markdown findings now surface as GitHub annotations instead of reviewdog pull request review comments. The job still fails on violations.
