### PR TITLE
chore(tombi): remove line-width limit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,6 @@ jobs:
               - '**/*.json5'
             toml:
               - '**/*.toml'
-              - .tombi.toml
             yaml:
               - '**/*.yml'
               - '**/*.yaml'

--- a/.tombi.toml
+++ b/.tombi.toml
@@ -1,3 +1,0 @@
-[format]
-[format.rules]
-line-width = 120


### PR DESCRIPTION
Adopt Tombi's default `line-width`, which became unlimited in v1.3.2 so that formatting no longer produces multi-line inline tables, a TOML v1.1 feature.

`.tombi.toml` configured nothing else, so it is removed along with its entry in the changed-files filter: `tj-actions/changed-files` matches patterns with `dot: true`, so `**/*.toml` already covers it.

Verified with Tombi 1.4.0 that no tracked TOML file changes as a result.
