### PR TITLE
chore(rumdl): auto-fix Markdown violations in the rumdl hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
     rev: 4f7fb84c204d04a8b458ad18ca6cd63417d524a9  # frozen: v0.2.55
     hooks:
       - id: rumdl
+        args: ["--fix"]
 
   - repo: https://github.com/tombi-toml/tombi-pre-commit
     rev: dd68bbd8cdd8891c942fb6f33a6e87a477b2c375  # frozen: v1.4.1


### PR DESCRIPTION
Pass `--fix` to the `rumdl` prek hook so it repairs fixable Markdown violations instead of only reporting them.

- Aligns Markdown with the other fixing hooks in this config (`shfmt`, `tombi-format`, `end-of-file-fixer`): hooks fix, CI verifies.
- The `rumdl-fmt` hook is deliberately not added. `rumdl fmt` and `rumdl check --fix` produce byte-identical output and the same diagnostics; they differ only in the exit code when unfixable violations remain, so `rumdl-fmt` would be pure redundancy.
- CI is left unchanged (`rumdl check` with `report-type: annotations`). A separate format-check step would add no detection, because every change `rumdl fmt` makes is already reported by `rumdl check`, and `fmt --check` emits a diff rather than GitHub annotations.

No content changes: `README.md` is already clean under both `rumdl check` and `rumdl fmt --check`.
